### PR TITLE
Using main as branch of deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '34 2 * * *' # run every day at 2:34 AM
 


### PR DESCRIPTION
Switched the default branch to `main` as well. Follow the instruction on https://github.com/uclaacm/hoth.uclaacm.com/issues/36#issuecomment-647033264 to use new `main` default branch. 