### PR TITLE
shrink height of banner and event title font

### DIFF
--- a/src/components/EventCard/EventCard.js
+++ b/src/components/EventCard/EventCard.js
@@ -58,7 +58,7 @@ const styles = theme => ({
 		}
 	},
 	banner: {
-		height: '200px',
+		height: '175px',
 		// adjust image to cover the entire box
 		objectFit: 'cover',
 		// this is a workaround for a Safari/Chrome bug on iOS
@@ -75,7 +75,7 @@ const styles = theme => ({
 		fontFamily: theme.typography.fontFamily,
 		fontWeight: 400,
 		margin: theme.spacing(0),
-		fontSize: theme.typography.fontSize / 14 * 24
+		fontSize: theme.typography.fontSize / 16 * 24
 	},
 	details: {
 		fontSize: theme.typography.fontSize / 16 * 14

--- a/src/components/EventCard/EventCard.js
+++ b/src/components/EventCard/EventCard.js
@@ -185,7 +185,7 @@ export const query = graphql`
 		conferenceLink
 		imgFile {
 			childImageSharp {
-				fluid(maxWidth: 520, srcSetBreakpoints: [260, 390], maxHeight: 400,
+				fluid(maxWidth: 520, srcSetBreakpoints: [260, 390], maxHeight: 350,
 							quality: 75, fit: COVER, cropFocus: CENTER) {
 					...GatsbyImageSharpFluid
 				}


### PR DESCRIPTION
Adjusted banner height and font size of event card titles to accommodate for 3 line titles. 

3 line title: 
<img height='200px' src='https://user-images.githubusercontent.com/44387428/114133592-20b57000-98bb-11eb-8b63-fcb8049e65e3.png'>

2 line title: 
<img height='200px' src='https://user-images.githubusercontent.com/44387428/114133614-29a64180-98bb-11eb-8d83-08766cdadebb.png'>

1 line title: 
<img height='200px' src='https://user-images.githubusercontent.com/44387428/114133648-37f45d80-98bb-11eb-8d74-d5a73a26f7b5.png'>




