### PR TITLE
Clean up archive tags

### DIFF
--- a/src/data/events/archive/fall2017/hackschool.yml
+++ b/src/data/events/archive/fall2017/hackschool.yml
@@ -52,4 +52,4 @@
   - name: 'Hack Session 4: Final Project - BruinPlay'
     repo: https://github.com/acm-hackschool-f17/BruinPlay
     slides: https://docs.google.com/presentation/d/1pehGfdsiQjao58tpPrmfd4sV5Fxm-uAhfQ-SxjWwP3g
-    tags: ['bruinplay', 'final project']
+    tags: ['final project']

--- a/src/data/events/archive/fall2018/hackschool.yml
+++ b/src/data/events/archive/fall2018/hackschool.yml
@@ -33,7 +33,7 @@
   - name: 'Session 3 Backend: What is an API?'
     repo: https://github.com/uclaacm/hackschool-f18/tree/master/session-3-backend-api
     slides: https://docs.google.com/presentation/d/1an6ZLx0g-eRDSchPjTg34yiSvxHBo_3w18jizYduuHU/edit?usp=sharing
-    tags: ['api', 'javascript', 'nodejs', 'expressjs']
+    tags: ['api', 'javascript', 'nodejs', 'express']
     presenter:
     - Galen Wong
 
@@ -47,7 +47,7 @@
   - name: 'Session 4 Backend: More on Express'
     repo: https://github.com/uclaacm/hackschool-f18/tree/master/session-4-backend-express
     slides: https://docs.google.com/presentation/d/1Wi0yGGNhE4G9G1uWtA9yNo0OWv3_CTG7iaMpm8VeQso/edit?usp=sharing
-    tags: ['api', 'nodejs', 'expressjs']
+    tags: ['api', 'nodejs', 'express']
     presenter:
     - Timothy Gu
 

--- a/src/data/events/archive/fall2019/hackschool.yml
+++ b/src/data/events/archive/fall2019/hackschool.yml
@@ -38,7 +38,7 @@
   - name: 'Session 4 Backend: Introduction to Express.js'
     repo: https://github.com/uclaacm/hackschool-f19/tree/master/session-4-backend-express
     slides: https://docs.google.com/presentation/d/1cy9AZdiZY5d3i59HL3ltGb1w0KX_-FNHHKZteRpa-ic/edit?usp=sharing
-    tags: ['expressjs', 'nodejs']
+    tags: ['express', 'nodejs']
     presenter:
     - Galen Wong
 

--- a/src/data/events/archive/fall2020/hackschool.yml
+++ b/src/data/events/archive/fall2020/hackschool.yml
@@ -53,7 +53,7 @@
     repo: https://github.com/uclaacm/hackschool-f20/tree/main/session-6-responsive-design-and-accessibility
     slides: https://docs.google.com/presentation/d/1PewBRZg2rGFnFLq39CNQ5n6QQhIzCmF8QyqkZ0nqK2E/edit?usp=sharing
     youtube: https://www.youtube.com/watch?v=jy_OtcErlRY
-    tags: ['css', 'screenreader', 'responsive', 'accessiblity']
+    tags: ['css', 'screenreader', 'design', 'accessiblity']
     presenter:
     - Kristie Lim
 
@@ -70,7 +70,7 @@
     repo: https://github.com/uclaacm/hackschool-f20/tree/main/session-8-nodejs
     slides: https://docs.google.com/presentation/d/1rqqjR0cUZ00GUgosRk4idZ7Jok8vxrNd9diy-FuEv9g/edit?usp=sharing
     youtube: https://www.youtube.com/watch?v=Av_8nU-IOJ8
-    tags: ['nodejs', 'javascript', 'expressjs']
+    tags: ['nodejs', 'javascript', 'express']
     presenter:
     - Jamie Liu
     - Timothy Gu

--- a/src/data/events/archive/spring2018/learnjs.yml
+++ b/src/data/events/archive/spring2018/learnjs.yml
@@ -50,6 +50,6 @@
   - name: 'React'
     repo: https://github.com/acm-learnjs-sp18/react
     slides: https://docs.google.com/presentation/d/1dvlSBL0S7NoW07r-kzG8hr7-ukp2DcvQatZZvFQ31xM/edit?usp=sharing
-    tags: ['reactjs', 'todo list']
+    tags: ['reactjs']
     presenter:
     - Kevin Qian

--- a/src/data/events/archive/spring2019/learnpy.yml
+++ b/src/data/events/archive/spring2019/learnpy.yml
@@ -38,7 +38,7 @@
   - name: 'Session 5: Data Mining and Modeling'
     repo: https://github.com/uclaacm/learn.py-s19/tree/master/session-5-data-mining
     slides: https://docs.google.com/presentation/d/1Pi9cKz1Cp7yRLd790zy2qqC0cIwWjxn1vqgdj3m1O-Q/edit?usp=sharing
-    tags: ['data mining', 'ai', 'ml', 'colab', 'regression', 'sklearn']
+    tags: ['data mining', 'ai', 'machine learning', 'colab', 'regression', 'sklearn']
     presenter:
     - Kevin Tan
 
@@ -52,7 +52,7 @@
   - name: 'Session 7: Web Dev Part 2'
     repo: https://github.com/uclaacm/learn.py-s19/tree/master/session-7-web-development-2
     slides: https://docs.google.com/presentation/d/1WtkbIpaLZH94XGXe5nCp6tUKjvTAurjVVlZGr9ZPLtY/edit?usp=sharing
-    tags: ['django', 'rpc', 'javascript', 'rest', 'json']
+    tags: ['django', 'javascript', 'api', 'json']
     presenter:
     - Galen Wong
 

--- a/src/data/events/archive/winter2021/hack-sprint.yml
+++ b/src/data/events/archive/winter2021/hack-sprint.yml
@@ -18,11 +18,11 @@
     repo: https://github.com/uclaacm/hack-sprint-w21/tree/master/session-2-jsx-and-basic-components
     slides: https://docs.google.com/presentation/d/1CSmRlOHPBkwrHoFmJ0Xykhd24xT88uoutF0hkM1Vp-I/edit
     youtube: https://www.youtube.com/watch?v=uFDSDHlowX0
-    tags: ['jsx', 'components', 'stylesheet']
+    tags: ['jsx', 'components']
     presenter:
     - Miles Wu
     - Nareh Agazaryan
-  
+
   - name: 'Session 3: Controllable and User Interactive Components'
     repo: https://github.com/uclaacm/hack-sprint-w21/tree/master/session-3-controllable-and-user-interactive-components
     slides: https://docs.google.com/presentation/d/1CFHQJbP3yjPwIC5k-P54keLMCesm_KGCFploDaRCt_g/edit
@@ -31,7 +31,7 @@
     presenter:
     - Alex Xia
     - Jody Lin
-  
+
   - name: 'Session 4: Intro to React Navigation'
     repo: https://github.com/uclaacm/hack-sprint-w21/tree/master/session-4-intro-to-react-navigation
     slides: https://docs.google.com/presentation/d/1k9wRedzUvguCoYfP7K1bTStT9V3x482vlKd178t0GJ8/edit

--- a/src/data/events/archive/winter2021/hoth-8.yml
+++ b/src/data/events/archive/winter2021/hoth-8.yml
@@ -37,14 +37,14 @@
     youtube: https://youtu.be/RKauOuvaoKo
     repo: https://github.com/Timthetic/hoth-api-workshop/blob/main/readme.md
     slides: https://docs.google.com/presentation/d/1Fh6dLO-jxaVvAQMFmnP2M-kX2PdtlL_TMcP6DCNMIdE/edit#slide=id.gb62b40d382_0_0
-    tags: ['api', 'request']
+    tags: ['api']
     presenter:
     - Timothy Rediehs
   - name: Intro to Servers
     youtube: https://youtu.be/_1W4xcT2lYc
     repo: https://github.com/uclaacm/hoth8-server
     slides: https://docs.google.com/presentation/d/1h6KdlwfDfh8SBBBxGMGJb0OhJ5vSLsI2L9Zz3Yn7BR0/edit#slide=id.gb62b40d382_0_5
-    tags: ['server', 'http', 'json']
+    tags: ['http', 'json', 'nodejs']
     presenter:
     - Timothy Gu
   - name: Intro to Servers Demo
@@ -74,7 +74,7 @@
     youtube: https://youtu.be/c8dGnJuqLY0
     repo: https://github.com/uclaacm/hoth8-react-native-workshop
     slides: https://docs.google.com/presentation/d/1DF-JPTYbFgY0AaYZRqDyZG6WiOtRnyFPI-lp-JA3CtY/edit
-    tags: ['jsx', 'props', 'state', 'stylesheets']
+    tags: ['jsx', 'props', 'state']
     presenter:
     - Einar Balan
   - name: Intro to Git


### PR DESCRIPTION
#205 

Cleaned up the tags in the yaml files. 
``` txt
deleted:
[old] -> [new]

ml -> machine learning
expressjs -> express
passion ->
stylesheet -> 
stylesheets -> 
todo list ->
bruinplay ->
request ->
responsive -> design
server -> 
rpc ->
rest -> api
```
TODO: policy checks for future workshops -> add a sentence or two in the README about which tags to avoid and a recommendation to use existing tags.
TODO: programmatic checks -> Add a check in `gatsby-node.js` to filter out bad tags.