### PR TITLE
Added the option to have an author in the blog page and each blog post in the metadata

### DIFF
--- a/posts/spring2021/js-chats-6-hooks/index.md
+++ b/posts/spring2021/js-chats-6-hooks/index.md
@@ -2,6 +2,7 @@
 date: 2021-05-18
 title: Advanced React Hooks
 subtitle: JavaScript Chats Hack Session 6, Spring 2021
+author: Tristan Que
 description: >
   A survey of advanced React hooks, including useRef, useReducer, useContext
   and custom hooks.

--- a/posts/spring2021/js-chats-7-typescript/index.md
+++ b/posts/spring2021/js-chats-7-typescript/index.md
@@ -1,7 +1,8 @@
 ---
 date: 2021-05-25
 title: TypeScript - What is it and why should I care?
-subtitle: JavaScript Chats Hack Session 7, Spring 2021
+subtitle: JavaScript Chats Hack Session 7, Spring 202
+author: Omer Demirkan
 description: >
   An exploration of what TypeScript is and how to use it to catch type safety errors in development.
 ---

--- a/posts/spring2021/js-chats-7-typescript/index.md
+++ b/posts/spring2021/js-chats-7-typescript/index.md
@@ -1,7 +1,7 @@
 ---
 date: 2021-05-25
 title: TypeScript - What is it and why should I care?
-subtitle: JavaScript Chats Hack Session 7, Spring 202
+subtitle: JavaScript Chats Hack Session 7, Spring 2021
 author: Omer Demirkan
 description: >
   An exploration of what TypeScript is and how to use it to catch type safety errors in development.

--- a/posts/spring2021/year-in-review/index.md
+++ b/posts/spring2021/year-in-review/index.md
@@ -2,9 +2,8 @@
 date: 2021-07-30
 title: '2020-2021 year: a reflection'
 subtitle: 'a look back on the past year in quarantine'
+author: 'Jody Lin'
 ---
-
-_By Jody Lin_
 
 I had been mulling over the idea of a fun blog post here for a while now and finally just decided to go for it. Although our existing blogs are technical masterpieces written for our JSChats series (a deep dive into advanced JavaScript), I am using my remaining executive powers from my previous term as VP to inject a fun blog recapping the past year. If this doesn't serve as a record of what our club did this year, then it'll serve as a love letter from me to the officers in Hack that have been my family for the past 3 years. 
 

--- a/src/components/BlogPage/BlogListItem.js
+++ b/src/components/BlogPage/BlogListItem.js
@@ -10,7 +10,8 @@ function BlogListItem({
 	excerpt,
 	date,
 	timeToRead,
-	url
+	url,
+	author
 }) {
 	return (
 		<article>
@@ -23,7 +24,7 @@ function BlogListItem({
 				{subtitle}
 			</Typography>
 			<Typography gutterBottom>
-				{date} | {timeToRead} min read
+				{ author ? `by ${author} |` : ''} {date} | {timeToRead} min read
 			</Typography>
 			<Typography color="textSecondary" gutterBottom>
 				{excerpt}
@@ -37,6 +38,7 @@ BlogListItem.propTypes = {
 	subtitle: PropTypes.string.isRequired,
 	excerpt: PropTypes.string.isRequired,
 	date: PropTypes.string.isRequired,
+	author: PropTypes.string,
 	timeToRead: PropTypes.number.isRequired,
 	url: PropTypes.string.isRequired
 };

--- a/src/components/BlogPage/BlogPageList.js
+++ b/src/components/BlogPage/BlogPageList.js
@@ -12,6 +12,7 @@ function BlogPageList({ data }) {
 				title={blog.frontmatter.title}
 				subtitle={blog.frontmatter.subtitle}
 				date={blog.frontmatter.date}
+				author={blog.frontmatter.author}
 				excerpt={blog.excerpt}
 				timeToRead={blog.timeToRead}
 				url={blog.fields.slug}

--- a/src/components/BlogPage/BlogPageTemplate.js
+++ b/src/components/BlogPage/BlogPageTemplate.js
@@ -115,6 +115,7 @@ query BlogPageListInfo($lim: Int!, $toskip: Int!) {
 				date(formatString: "MMMM D, YYYY")
 				subtitle
 				title
+				author
 		  }
 		  fields {
 				slug

--- a/src/components/Post/Post.js
+++ b/src/components/Post/Post.js
@@ -14,6 +14,9 @@ const styles = theme => ({
 	},
 	date: {
 		color: theme.palette.grey[500]
+	},
+	author: {
+		fontStyle: 'italic'
 	}
 });
 
@@ -21,7 +24,7 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 	year: 'numeric', month: 'long', day: 'numeric'
 });
 
-function Post({ title, subtitle, date, html, classes }) {
+function Post({ title, subtitle, date, author, html, classes }) {
 	const formattedDate = dateFormatter.format(date);
 
 	return (
@@ -35,6 +38,9 @@ function Post({ title, subtitle, date, html, classes }) {
 			<Typography variant="body1" gutterBottom className={classes.date}>
 				{formattedDate}
 			</Typography>
+			<Typography variant="body2" className={classes.author}>
+				{author ? `By ${author}` : ''}
+			</Typography>
 			<MDContainer html={html} />
 		</Container>
 	);
@@ -44,6 +50,7 @@ Post.propTypes = {
 	title: PropTypes.string.isRequired,
 	subtitle: PropTypes.string.isRequired,
 	date: PropTypes.instanceOf(Date).isRequired,
+	author: PropTypes.string,
 	html: PropTypes.string.isRequired,
 	classes: PropTypes.object.isRequired
 };

--- a/src/components/Post/PostTemplate.js
+++ b/src/components/Post/PostTemplate.js
@@ -9,7 +9,7 @@ import SEO from '../SEO';
 
 function PostTemplate({ data }) {
 	const { frontmatter, html } = data.markdownRemark;
-	const { date, title, subtitle } = frontmatter;
+	const { date, title, subtitle, author } = frontmatter;
 	// The built-in Date constructor that parses a date string does so in UTC,
 	// which we do not want. Dayjs, however, parses it in the current timezone.
 	const dateObj = dayjs(date).toDate();
@@ -27,6 +27,7 @@ function PostTemplate({ data }) {
 				title={title}
 				subtitle={subtitle}
 				date={dateObj}
+				author={author}
 				html={html}
 			/>
 		</HeadFooter>
@@ -40,7 +41,8 @@ PostTemplate.propTypes = {
 			frontmatter: PropTypes.exact({
 				date: PropTypes.string.isRequired,
 				title: PropTypes.string.isRequired,
-				subtitle: PropTypes.string.isRequired
+				subtitle: PropTypes.string.isRequired,
+				author: PropTypes.string
 			}).isRequired
 		}).isRequired
 	}).isRequired
@@ -56,6 +58,7 @@ export const pageQuery = graphql`
         date
 				title
 				subtitle
+				author
       }
     }
   }


### PR DESCRIPTION
This corresponds to issue #239 

# Changes
* Now, if we specify an author in the metadata, it will be rendered in the blog page and the blog post. If no author is specified in the metadata, it will be ignored.
* The latest three blog post's metadata, (by Jody Lin, Omer Demirkan, and Tristan Que), have been updated with their corresponding authors. 
