### PR TITLE
Added spacing to bottom of 404 page

### DIFF
--- a/src/components/NotFoundPage/NotFoundPage.js
+++ b/src/components/NotFoundPage/NotFoundPage.js
@@ -13,7 +13,8 @@ const styles = theme => ({
 		alignItems: 'center',
 		justifyContent: 'center',
 		flexDirection: 'column',
-		marginTop: theme.spacing(3)
+		marginTop: theme.spacing(3),
+		marginBottom: theme.spacing(6)
 	},
 	content: {
 		fontFamily: theme.typography.body1.fontFamily,


### PR DESCRIPTION
# Changes

Fixing margin at the bottom of the 404 page between the content and the footer.

## Type of change

Please delete options that are not relevant.

- [ ] Content Update (non-breaking change which updates the content of the website)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Related Issues

#256 
