### PR TITLE
add fb event link for hack sprint session 2

### DIFF
--- a/src/data/events/events.js
+++ b/src/data/events/events.js
@@ -26,7 +26,7 @@ const events = [
 		location: 'Zoom',
 		imgFilePath: 'event/2022w-hacksprint-banner.png',
 		conferenceLink: 'https://ucla.zoom.us/j/93761587241?pwd=aWlsV3FxRzl6clVhRDQ0RHF4dmN6dz09',
-		// detailLink: 'https://fb.me/e/1AamI7NeY'
+		detailLink: 'https://fb.me/e/1tUUXAlUI'
 	},
 	{
 		name: 'Hack Sprint #3: State and Bindings',


### PR DESCRIPTION
# Changes

Added the link for hacksprint session 2

## Type of change

Please delete options that are not relevant.

- [x] Content Update (non-breaking change which updates the content of the website)
# Related Issues

Link the relevant issue here
