### PR TITLE
Added Hack Sprint events for rest of the quarter

### DIFF
--- a/src/data/events/events.js
+++ b/src/data/events/events.js
@@ -34,7 +34,44 @@ const events = [
 		location: 'Zoom',
 		imgFilePath: 'event/2022w-hacksprint-banner.png',
 		conferenceLink: 'https://ucla.zoom.us/j/93761587241?pwd=aWlsV3FxRzl6clVhRDQ0RHF4dmN6dz09',
-		// detailLink: 'https://fb.me/e/1AamI7NeY'
+		detailLink: 'https://fb.me/e/5a8xQLIpQ'
+	},
+	{
+		name: 'Hack Sprint #4: Advanced Views',
+		date: getDateTime(2022, 02, 02, 18),
+		location: 'Zoom',
+		imgFilePath: 'event/2022w-hacksprint-banner.png',
+		conferenceLink: 'https://ucla.zoom.us/j/93761587241?pwd=aWlsV3FxRzl6clVhRDQ0RHF4dmN6dz09',
+		detailLink: 'https://fb.me/e/2mfoAxupx'
+	},
+	{
+		name: 'Hack Sprint #5: Data and Networking',
+		date: getDateTime(2022, 02, 09, 18),
+		location: 'Zoom',
+		imgFilePath: 'event/2022w-hacksprint-banner.png',
+		conferenceLink: 'https://ucla.zoom.us/j/93761587241?pwd=aWlsV3FxRzl6clVhRDQ0RHF4dmN6dz09',
+		detailLink: 'https://fb.me/e/3z2IY6Dif'
+	},
+	{
+		name: 'Hack Sprint #6: Guest Speaker + Work Session',
+		date: getDateTime(2022, 02, 16, 18),
+		location: 'TBD',
+		imgFilePath: 'event/2022w-hacksprint-banner.png',
+		detailLink: 'https://fb.me/e/1Au0bckPy'
+	},
+	{
+		name: 'Hack Sprint #7: Guest Speaker + Work Session',
+		date: getDateTime(2022, 02, 23, 18),
+		location: 'TBD',
+		imgFilePath: 'event/2022w-hacksprint-banner.png',
+		detailLink: 'https://fb.me/e/1DWt36X25'
+	},
+	{
+		name: 'Hack Sprint #8: Project Showcase',
+		date: getDateTime(2022, 03, 02, 18),
+		location: 'TBD',
+		imgFilePath: 'event/2022w-hacksprint-banner.png',
+		detailLink: 'https://fb.me/e/1evDL3IKB'
 	}
 ];
 


### PR DESCRIPTION
# Changes

Added Hack Sprint events for the rest of the quarter
- Guest speaker + work session locations are still TBD, along with their names
- project showcase location still TBD
- Pre-generated all the facebook event links, even though they will not have updated baner, it shouldn't cause too much confusion. This creates less work on our end. 

## Type of change

Please delete options that are not relevant.

- [x] Content Update (non-breaking change which updates the content of the website)

# Related Issues
