### PR TITLE
Updated HTT event dates and HackSpace FB Link

### DIFF
--- a/src/data/events/events.js
+++ b/src/data/events/events.js
@@ -41,13 +41,13 @@ const events = [
 	},
 	{
 		name: 'Hot Tech Tours: Svelte',
-		date: getDateTime(2022, 4, 27, 18),
+		date: getDateTime(2022, 5, 4, 18),
 		imgFilePath: 'event/2022s-htt-banner.png',
 		location: 'Boelter Hall 9436',
 		detailLink: 'https://fb.me/e/1JS1j6ske'
 	},
 	{
-		name: 'HackSpace: Figma + Work Session',
+		name: 'HackSpace: Figma & Further',
 		date: getDateTime(2022, 4, 28, 18),
 		imgFilePath: 'event/2022s-hackspace-banner.png',
 		location: 'Math Sciences 6229',
@@ -55,7 +55,7 @@ const events = [
 	},
 	{
 		name: 'Hot Tech Tours: Puzzle Night',
-		date: getDateTime(2022, 5, 4, 18),
+		date: getDateTime(2022, 5, 10, 18),
 		imgFilePath: 'event/2022s-htt-banner.png',
 		location: 'Boelter Hall 9436',
 		detailLink: 'https://fb.me/e/1JS1j6ske'
@@ -69,7 +69,7 @@ const events = [
 	},
 	{
 		name: 'Hot Tech Tours: Firebase',
-		date: getDateTime(2022, 5, 11, 18),
+		date: getDateTime(2022, 5, 18, 18),
 		imgFilePath: 'event/2022s-htt-banner.png',
 		location: 'Boelter Hall 9436',
 		detailLink: 'https://fb.me/e/1JS1j6ske'
@@ -83,7 +83,7 @@ const events = [
 	},
 	{
 		name: 'Hot Tech Tours: Puzzle Night',
-		date: getDateTime(2022, 5, 18, 18),
+		date: getDateTime(2022, 5, 25, 18),
 		imgFilePath: 'event/2022s-htt-banner.png',
 		location: 'Boelter Hall 9436',
 		detailLink: 'https://fb.me/e/1JS1j6ske'

--- a/src/data/events/events.js
+++ b/src/data/events/events.js
@@ -37,7 +37,7 @@ const events = [
 		date: getDateTime(2022, 4, 21, 18),
 		imgFilePath: 'event/2022s-hackspace-banner.png',
 		location: 'Math Sciences 6229',
-		detailLink: 'https://fb.me/e/1abuEJLFD'
+		detailLink: 'https://fb.me/e/1GGKX9O3e'
 	},
 	{
 		name: 'Hot Tech Tours: Svelte',

--- a/src/data/events/events.js
+++ b/src/data/events/events.js
@@ -37,7 +37,7 @@ const events = [
 		date: getDateTime(2022, 4, 21, 18),
 		imgFilePath: 'event/2022s-hackspace-banner.png',
 		location: 'Math Sciences 6229',
-		detailLink: 'https://fb.me/e/1GGKX9O3e'
+		detailLink: 'https://fb.me/e/1abuEJLFD'
 	},
 	{
 		name: 'Hot Tech Tours: Svelte',
@@ -51,7 +51,7 @@ const events = [
 		date: getDateTime(2022, 4, 28, 18),
 		imgFilePath: 'event/2022s-hackspace-banner.png',
 		location: 'Math Sciences 6229',
-		detailLink: 'https://fb.me/e/1abuEJLFD'
+		detailLink: 'https://fb.me/e/1GGKX9O3e'
 	},
 	{
 		name: 'Hot Tech Tours: Puzzle Night',


### PR DESCRIPTION
# Changes

- Corrected HTT event dates based on meeting (skipping week 5, week 7 moved to Tuesday for town hall)
- Update weekly HackSpace FB Link and event name to be consistent

## Type of change

Please delete options that are not relevant.

- [x] Content Update (non-breaking change which updates the content of the website)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Related Issues

N/A
