### PR TITLE
Add studio presenter to HOTH 9 Workshop

### DIFF
--- a/src/data/events/archive/winter2022/hoth-9.yml
+++ b/src/data/events/archive/winter2022/hoth-9.yml
@@ -79,6 +79,8 @@
       youtube: https://www.youtube.com/watch?v=D_mbel-Q5_0
       slides: https://docs.google.com/presentation/d/1fjDNeCgPOvp4xe2yMorYeOHJZrXBI7NZ8eqSt9Fm-0Q/edit
       tags: ["unity"]
+      presenters:
+        - Peter Sutarjo
     - name: Intro to Machine Learning
       youtube: https://www.youtube.com/watch?v=byTbOGoAbRI
       slides: https://docs.google.com/presentation/d/15iGiw78UcoYgqZZR7BHfVzRGgzhXFz8Imok-OwMTWXQ/edit


### PR DESCRIPTION
# Changes

Looks like we forgot to add peter for the presenter to the unity workshop

## Type of change

Please delete options that are not relevant.

[x] Bug fix (non-breaking change which fixes an issue)


# Related Issues


