### PR TITLE
Linking to an expanded workshop archive

### DIFF
--- a/src/components/ArchivePage/ArchivePageTemplate.js
+++ b/src/components/ArchivePage/ArchivePageTemplate.js
@@ -67,19 +67,27 @@ function ArchivePageTemplate({ pageContext }) {
 		quarterEvents[event].sort((first, second) => cmp(first.name, second.name));
 	}
 	allTags.sort((first, second) => cmp(first.displayName, second.displayName));
-	const allEvents = quarterList.map(quarter =>
+	const allEvents = quarterList.map(quarter => 		
 		<div className={classes.quarterItem} key={quarter}>
 			<Typography variant='h5' component='h2'>{quarter}</Typography>
 			<div className={classes.quarterEvent}>
-				{quarterEvents[quarter].map(event =>
-					<EventInfoItem
-						key={event.name}
-						name={event.name}
-						mainLink={event.mainLink}
-						tags={event.tags}
-						directors={event.directors}
-						workshops={event.workshops}
-					/>)}
+				{quarterEvents[quarter].map(event => {
+					// name = quarter + " " + event.name
+					// slug = replace all whitespace in name with "-"
+					console.log(quarter)
+					const quarterAndYearAndEvent = quarter + " " + event.name;
+					const slug = quarterAndYearAndEvent.replaceAll(" ", "-").toLowerCase();
+					console.log(slug)
+					return (
+						<EventInfoItem
+							key={event.name}
+							name={event.name}
+							mainLink={event.mainLink}
+							tags={event.tags}
+							directors={event.directors}
+							workshops={event.workshops}
+							slug={slug}
+						/>)})}
 			</div>
 		</div>);
 

--- a/src/components/ArchivePage/ArchivePageTemplate.js
+++ b/src/components/ArchivePage/ArchivePageTemplate.js
@@ -74,10 +74,8 @@ function ArchivePageTemplate({ pageContext }) {
 				{quarterEvents[quarter].map(event => {
 					// name = quarter + " " + event.name
 					// slug = replace all whitespace in name with "-"
-					console.log(quarter)
 					const quarterAndYearAndEvent = quarter + " " + event.name;
 					const slug = quarterAndYearAndEvent.replaceAll(" ", "-").toLowerCase();
-					console.log(slug)
 					return (
 						<EventInfoItem
 							key={event.name}

--- a/src/components/ArchivePage/ArchivePageTemplate.js
+++ b/src/components/ArchivePage/ArchivePageTemplate.js
@@ -72,8 +72,6 @@ function ArchivePageTemplate({ pageContext }) {
 			<Typography variant='h5' component='h2'>{quarter}</Typography>
 			<div className={classes.quarterEvent}>
 				{quarterEvents[quarter].map(event => {
-					// name = quarter + " " + event.name
-					// slug = replace all whitespace in name with "-"
 					const quarterAndYearAndEvent = quarter + " " + event.name;
 					const slug = quarterAndYearAndEvent.replaceAll(" ", "-").toLowerCase();
 					return (

--- a/src/components/ArchivePage/EventInfoItem.js
+++ b/src/components/ArchivePage/EventInfoItem.js
@@ -56,17 +56,17 @@ const useStyles = makeStyles(theme => ({
 function EventInfoItem({ name, mainLink, tags, directors, workshops, tagHighlight, slug }) {
 	const classes = useStyles();
 	const [isExpanded, setExpanded] = useState(false);
-	console.log(name)
-	console.log(`window: `, window.location.hash)
-	const [hash, setHash] = useState(window.location.hash);
+	const [hash, setHash] = useState('');
+	useEffect(() => {
+		setHash(window.location.hash);
+	}, []);
 	useEffect (() => {
-		console.log(`useEffect run`)
 		if (`#${slug}`=== hash) 
 		{
-			console.log(`here`); 
 			setExpanded(true);
 		}
-	}, [hash])
+	}, [hash]);
+
 	return (
 		<Accordion 
 			id={slug} 
@@ -85,10 +85,9 @@ function EventInfoItem({ name, mainLink, tags, directors, workshops, tagHighligh
 						fontSize='medium'
 						color='primary'
 						onClick={event => {
-							window.history.pushState({accordian: slug}, slug,`/archive#${slug}`)
+							window.history.pushState({accordian: slug}, '',`/archive#${slug}`)
 							event.stopPropagation()
 							setHash(window.location.hash)
-							console.log(`window: `, window.location.hash)
 						}}
 						className={classes.formControl}
 					/>

--- a/src/components/ArchivePage/EventInfoItem.js
+++ b/src/components/ArchivePage/EventInfoItem.js
@@ -50,10 +50,11 @@ const useStyles = makeStyles(theme => ({
 	}
 }));
 
-function EventInfoItem({ name, mainLink, tags, directors, workshops, tagHighlight }) {
+function EventInfoItem({ name, mainLink, tags, directors, workshops, tagHighlight, slug }) {
 	const classes = useStyles();
 	const [isExpanded, setExpanded] = useState(true);
-	return <Accordion classes={{ root: classes.paperRoot }}
+	console.log(name)
+	return <Accordion id={slug} classes={{ root: classes.paperRoot }}
 		onChange={() => setExpanded(e => !e)}>
 		<AccordionSummary
 			expandIcon={isExpanded ? <AddIcon /> : <RemoveIcon/>}
@@ -123,7 +124,8 @@ EventInfoItem.propTypes = {
 	tags: PropTypes.array.isRequired,
 	directors: PropTypes.array,
 	workshops: PropTypes.array,
-	tagHighlight: PropTypes.string
+	tagHighlight: PropTypes.string,
+	slug: PropTypes.string
 };
 
 export default EventInfoItem;

--- a/src/components/ArchivePage/EventInfoItem.js
+++ b/src/components/ArchivePage/EventInfoItem.js
@@ -8,6 +8,7 @@ import { Accordion, AccordionSummary, AccordionDetails, FormControlLabel } from 
 import AddIcon from '@material-ui/icons/Add';
 import RemoveIcon from '@material-ui/icons/Remove';
 import LaunchIcon from '@material-ui/icons/Launch';
+import LinkOutlinedIcon from '@material-ui/icons/LinkOutlined';
 import { makeStyles } from '@material-ui/core/styles';
 import WorkshopInfoItem from './WorkshopInfoItem';
 import { ListFormat } from '../../utils/intl';
@@ -26,7 +27,7 @@ const useStyles = makeStyles(theme => ({
 		alignItems: 'center'
 	},
 	formControl: {
-		margin: theme.spacing(0.25, 1)
+		margin: theme.spacing(.2, 1)
 	},
 	link: {
 		padding: '0px'
@@ -63,16 +64,22 @@ function EventInfoItem({ name, mainLink, tags, directors, workshops, tagHighligh
 				<div className={classes.eventName}>
 					<Typography variant="h6" component="h2" className={classes.name}>
 						{name}
-						<FormControlLabel
-							aria-label="Launch"
-							onClick={event => event.stopPropagation()}
-							onFocus={event => event.stopPropagation()}
-							className={classes.formControl}
-							control={<Link href={mainLink} className={classes.link} aria-label={name}>
-								<LaunchIcon fontSize='small' color='primary' />
-							</Link>}
-						/>
 					</Typography>
+					<LinkOutlinedIcon
+						fontSize='medium'
+						color='primary'
+						onClick={() => {window.history.pushState({accordian: slug}, slug,`/archive#${slug}`)}}
+						className={classes.formControl}
+					/>
+					<FormControlLabel
+						aria-label="Launch"
+						onClick={event => event.stopPropagation()}
+						onFocus={event => event.stopPropagation()}
+						className={classes.formControl}
+						control={<Link href={mainLink} className={classes.link} aria-label={name}>
+							<LaunchIcon fontSize='small' color='primary' />
+						</Link>}
+					/>
 				</div>
 				<div className={classes.chips}>
 					{tags.map(tag =>

--- a/src/components/ArchivePage/EventInfoItem.js
+++ b/src/components/ArchivePage/EventInfoItem.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 /* eslint-disable no-duplicate-imports */
@@ -27,16 +27,18 @@ const useStyles = makeStyles(theme => ({
 		alignItems: 'center'
 	},
 	formControl: {
-		margin: theme.spacing(.2, 1)
+		margin: theme.spacing(0, .5),
 	},
 	link: {
-		padding: '0px'
+		display: 'flex',
+		alignItems: 'center'
 	},
 	paperRoot: {
 		width: '100%'
 	},
 	name: {
-		lineHeight: '1.0'
+		lineHeight: '1.0',
+		margin: theme.spacing(0, .5)
 	},
 	chips: {
 		display: 'flex',
@@ -53,10 +55,24 @@ const useStyles = makeStyles(theme => ({
 
 function EventInfoItem({ name, mainLink, tags, directors, workshops, tagHighlight, slug }) {
 	const classes = useStyles();
-	const [isExpanded, setExpanded] = useState(true);
+	const [isExpanded, setExpanded] = useState(false);
 	console.log(name)
-	return <Accordion id={slug} classes={{ root: classes.paperRoot }}
-		onChange={() => setExpanded(e => !e)}>
+	console.log(`window: `, window.location.hash)
+	const [hash, setHash] = useState(window.location.hash);
+	useEffect (() => {
+		console.log(`useEffect run`)
+		if (`#${slug}`=== hash) 
+		{
+			console.log(`here`); 
+			setExpanded(true);
+		}
+	}, [hash])
+	return (
+		<Accordion 
+			id={slug} 
+			classes={{ root: classes.paperRoot }}
+			onChange={() => setExpanded(e => !e)}
+			expanded={isExpanded}>
 		<AccordionSummary
 			expandIcon={isExpanded ? <AddIcon /> : <RemoveIcon/>}
 		>
@@ -68,7 +84,12 @@ function EventInfoItem({ name, mainLink, tags, directors, workshops, tagHighligh
 					<LinkOutlinedIcon
 						fontSize='medium'
 						color='primary'
-						onClick={() => {window.history.pushState({accordian: slug}, slug,`/archive#${slug}`)}}
+						onClick={event => {
+							window.history.pushState({accordian: slug}, slug,`/archive#${slug}`)
+							event.stopPropagation()
+							setHash(window.location.hash)
+							console.log(`window: `, window.location.hash)
+						}}
 						className={classes.formControl}
 					/>
 					<FormControlLabel
@@ -122,8 +143,8 @@ function EventInfoItem({ name, mainLink, tags, directors, workshops, tagHighligh
 				}
 			</div>
 		</AccordionDetails>
-	</Accordion>;
-}
+	</Accordion> 
+)}
 
 EventInfoItem.propTypes = {
 	name: PropTypes.string.isRequired,

--- a/src/components/HomePage/HackDescription.js
+++ b/src/components/HomePage/HackDescription.js
@@ -54,6 +54,7 @@ class HackDescription extends React.Component {
 					className={classes.logo}
 					placeholder="none"
 					quality={100}
+					alt="Hack Logo"
 				/>
 				<div className={classes.description}>
 					<Typography variant="h4" classes={{ root: classes.title }}>


### PR DESCRIPTION
# Changes

- add ID to all accordions, so that adding quarter-year-eventName to the archive url will take you to the relevant accordion
- add a button that will copy the link to the accordion
- when linked to the accordion, the accordion will load as expanded

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# Related Issues

Fixes #167
