### PR TITLE
missing slug prop for EventInfoItem in TagPageTemplate.js fixed

### DIFF
--- a/src/components/ArchivePage/EventInfoItem.js
+++ b/src/components/ArchivePage/EventInfoItem.js
@@ -84,7 +84,11 @@ function EventInfoItem({ name, mainLink, tags, directors, workshops, tagHighligh
 							fontSize='medium'
 							color='primary'
 							onClick={event => {
-								window.history.pushState({ accordian: slug }, '', `/archive#${slug}`);
+								let url = window.location.pathname;
+								if (url[url.length-1] == "/") {
+									url=url.slice(0, url.length-1);
+								}
+								window.history.pushState({ accordian: slug }, '', `${url}#${slug}`);
 								event.stopPropagation();
 								setHash(window.location.hash);
 							}}

--- a/src/components/ArchivePage/EventInfoItem.js
+++ b/src/components/ArchivePage/EventInfoItem.js
@@ -84,11 +84,8 @@ function EventInfoItem({ name, mainLink, tags, directors, workshops, tagHighligh
 							fontSize='medium'
 							color='primary'
 							onClick={event => {
-								let url = window.location.pathname;
-								if (url[url.length-1] == "/") {
-									url=url.slice(0, url.length-1);
-								}
-								window.history.pushState({ accordian: slug }, '', `${url}#${slug}`);
+								const pathnameWithoutTrailingSlashes = window.location.pathname.replace(/\/+$/, '');
+								window.history.pushState({ accordian: slug }, '', `${pathnameWithoutTrailingSlashes}#${slug}`);
 								event.stopPropagation();
 								setHash(window.location.hash);
 							}}

--- a/src/components/ArchivePage/TagPageTemplate.js
+++ b/src/components/ArchivePage/TagPageTemplate.js
@@ -78,8 +78,11 @@ function TagPageTemplate({ pageContext }) {
 				<div className={classes.quarterItem} key={quarter}>
 					<Typography variant='h5'>{quarter}</Typography>
 					<div className={classes.quarterEvent}>
-						{quarterEventsTags[quarter].map(event =>
-							<EventInfoItem
+						{quarterEventsTags[quarter].map(event => {
+							const quarterAndYearAndEvent = quarter + ' ' + event.name;
+							const slug = quarterAndYearAndEvent.replaceAll(' ', '-').toLowerCase();
+							return (
+								<EventInfoItem
 								key={event.name}
 								name={event.name}
 								mainLink={event.mainLink}
@@ -87,7 +90,8 @@ function TagPageTemplate({ pageContext }) {
 								directors={event.directors}
 								workshops={event.workshops}
 								tagHighlight={tagName}
-							/>)}
+								slug={slug}
+							/>)})}
 					</div>
 				</div> :
 				null


### PR DESCRIPTION
# Changes

There was a bug that popped up when we clicked the link icon for an event in the archive page after sorting by tag. This PR adds in the missing slug prop into the call to EventInfoItem in TagPageTemplate that caused this bug.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)