### PR TITLE
fix: Removed Unnecessary Scheduling in GitHub Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
-  schedule:
-    - cron: '34 2 * * *' # run every day at 2:34 AM
 
 jobs:
   gh-pages-deploy:


### PR DESCRIPTION
Every day, I go on GitHub and see the following.

<img width="751" alt="image" src="https://user-images.githubusercontent.com/67720812/210162970-1c17c41d-6775-41d6-99ff-6d74e015c613.png">

Poor Timothy has graduated and yet is still working so diligently for the club via GitHub Actions!!! 🤣 ❤️ 

This pull request removes the cron scheduling for deployment from GitHub Actions. The reason is that the scheduling for deployment is unnecessary. There are only changes to source on a push to main which is already covered in the GitHub Action.