### PR TITLE
Update StackSchool Session 4 FB Link

### DIFF
--- a/src/data/events/events.js
+++ b/src/data/events/events.js
@@ -45,7 +45,7 @@ const events = [
 		date: getDateTime(2023, 2, 16, 18, 30),
 		location: 'Haines Hall A2',
 		imgFilePath: 'event/2023w-stackschool-banner.png',
-		detailLink: 'https://fb.me/e/2jb25JTVD'
+		detailLink: 'https://fb.me/e/2rIr1QARz'
 	},
 	{
 		name: 'StackSchool #5: Prettifying the React App',


### PR DESCRIPTION
# Changes

For the rest of the quarter, I'll probably still create FB links and update the event detail URLs with them. In the future we can discuss what link to put for events based on their marketing strategies.

## Type of change

- [X] Content Update (non-breaking change which updates the content of the website)

# Related Issues

N/A
