### PR TITLE
Update time for HackCloud

### DIFF
--- a/src/data/events.js
+++ b/src/data/events.js
@@ -28,7 +28,7 @@ const events = [
 	},
 	{
 		name: 'HackCloud #2: VM Computing',
-		date: getDateTime(2023, 4, 27, 19, 30),
+		date: getDateTime(2023, 4, 27, 18, 30),
 		location: 'Engineering VI 289',
 		imgFilePath: 'event/2023s-hackcloud-banner.png',
 		detailLink: 'https://discord.gg/rup2p6fxA5'
@@ -49,7 +49,7 @@ const events = [
 	},
 	{
 		name: 'HackCloud #5: Machine Learning',
-		date: getDateTime(2023, 5, 18, 19, 30),
+		date: getDateTime(2023, 5, 18, 18, 30),
 		location: 'Engineering VI 289',
 		imgFilePath: 'event/2023s-hackcloud-banner.png',
 		detailLink: 'https://discord.gg/rup2p6fxA5'


### PR DESCRIPTION
# Changes

Change time for HackCloud event cards for 4/27, 5/18 to be 630 pm rather than 730 pm

## Type of change

Please delete options that are not relevant.

- [x] Content Update (non-breaking change which updates the content of the website)

# Related Issues

