### PR TITLE
Add spring 2023 events to archive

### DIFF
--- a/src/data/archive/spring2023/hackcloud.yml
+++ b/src/data/archive/spring2023/hackcloud.yml
@@ -1,0 +1,62 @@
+- name: HackCloud
+  quarter: Spring 2023
+  mainLink: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud
+  tags: ['aws', 'cloud computing', 'machine learning', 's3', 'ec2']
+  directors:
+  - Andy Lewis
+  - Satyen Subramaniam
+
+  workshops:
+  - name: 'Session 1: Intro to Cloud'
+    repo: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud/Session%201_%20Intro%20to%20Cloud
+    slides: https://docs.google.com/presentation/d/1a9q5RX-Zm4N7WlFx7Xn0TanjuDSlVu6gsEcvSaeoXdE/edit?usp=sharing
+    youtube: https://youtu.be/A9TgYnsPwFs
+    tags: ['cloud computing', 'aws', 's3']
+    presenters:
+    - Satyen Subramaniam
+    - Katelyn Yu
+
+  - name: 'Session 2: VM Computing'
+    repo: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud/Session%202_%20VM%20Computing
+    slides: https://docs.google.com/presentation/d/1a04fSUrM0lNZvqn1KKDXmr3kwype8WE_KIRmebB54bs/edit?usp=sharing
+    youtube: https://youtu.be/y8cXeQsLIf0
+    tags: ['vm computing', 'aws', 'ec2']
+    presenters:
+    - Jonathan Si
+    - Satyen Subramaniam
+
+  - name: 'Session 3: Serverless Computing'
+    repo: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud/Session%203_%20Serverless%20Computing
+    slides: https://docs.google.com/presentation/d/1Ks0vzlODk4IIa13j1mklLcv2dN6veaHb4swsVQ57zlQ/edit?usp=sharing
+    youtube: https://youtu.be/_wzJBDLTmro
+    tags: ['serverless computing', 'crud api']
+    presenters:
+    - Einar Balan
+    - Andy Lewis
+  
+  - name: 'Session 4: DevOps + Cloud'
+    repo: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud/Session%204_%20DevOps%20and%20Cloud
+    slides: https://docs.google.com/presentation/d/1kzxU0wBjXY__MxoPIz92rYSou5qcdyTtQC6-lc1yRgU/edit?usp=sharing
+    youtube: https://youtu.be/ZllqqDFdAoc
+    tags: ['docker', 'elastic beanstalk', 'devops', 'aws']
+    presenters:
+    - Satyen Subramaniam
+    - Nathan Zhang
+  
+  - name: 'Session 5: Machine Learning'
+    repo: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud/Session%205_%20Machine%20Learning
+    slides: https://docs.google.com/presentation/d/1_G4iydzRv4GZYNY15agMmyg1VHfQp6wz4hbJKeobG4I/edit?usp=sharing
+    youtube: https://youtu.be/jL2SbQxiFGM
+    tags: ['machine learning', 'supervised learning', 'unsupervised learning', 'sagemaker', 'aws']
+    presenters:
+    - Brooke Jiang
+    - Andy Lewis
+  
+  - name: 'Session 6: Not Data Science. Minecraft'
+    repo: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud/Session%206_%20Data%20Science
+    slides: https://docs.google.com/presentation/d/1zu2H9r9IymC8v8msOat-LroUw3Pw0ztE8_Ln9WJS2to/edit?usp=sharing
+    youtube: https://youtu.be/_hEhW9STFmw
+    tags: ['minecraft', 'aws', 'ec2']
+    presenters:
+    - Einar Balan
+    - Andy Lewis

--- a/src/data/archive/spring2023/minihack.yml
+++ b/src/data/archive/spring2023/minihack.yml
@@ -1,0 +1,36 @@
+- name: MiniHack
+  quarter: Spring 2023
+  mainLink: https://docs.google.com/presentation/d/1KprArCBxcgrBCv54irmzQjL8SPE7N6KfHgDxwZGnn_U/edit?usp=sharing
+  tags: ['git', 'github',  'markdown', 'latex', 'shell', 'bash', 'vim']
+  directors:
+  - Abigail Tran
+  - Shiyu Ye
+
+  workshops:
+  - name: 'Session 1: Shell'
+    slides: https://docs.google.com/presentation/d/1ruy_EdASAHhLiDahdXc9-NhVxla4I9x-USpb4qSuWuY/edit?usp=sharing
+    tags: ['shell', 'bash']
+    presenters:
+    - Jakob Reinwald
+    - Shiyu Ye
+  
+  - name: 'Session 2: Git and GitHub'
+    slides: https://docs.google.com/presentation/d/1F5RhFQf6wL2ZlPuHPojoFckWtyn7v3m3-J0q34kCHvk/edit?usp=sharing
+    tags: ['git', 'github']
+    presenters:
+    - Christina Tong
+    - Abigail Tran
+
+  - name: 'Session 3: Vim'
+    slides: https://docs.google.com/presentation/d/1uGbL6g3_yZq_ccEk4-h8Ogndg_ZU7F2sJBca0HcxvZQ/edit?usp=sharing
+    tags: ['vim']
+    presenters:
+    - Jenna Wang
+    - James Wu
+
+  - name: 'Session 4: Markdown and LaTeX'
+    slides: https://docs.google.com/presentation/d/1I1ZfFWy-cRhBUB_bhCcytHT1vGnwNdvMSz4a7YziceE/edit?usp=sharing
+    tags: ['markdown', 'latex']
+    presenters:
+    - Maggie Li
+    - Shiyu Ye


### PR DESCRIPTION
# Changes

Add event information for HackCloud and MiniHack spring 2023 to archive

## Type of change

Please delete options that are not relevant.

- [x] Content Update (non-breaking change which updates the content of the website)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Related Issues

Link the relevant issue here

There is none. I lone-rangered this :)
