### PR TITLE
update gaming social event card

### DIFF
--- a/src/data/events.js
+++ b/src/data/events.js
@@ -42,8 +42,8 @@ const events = [
 	},
 	{
 		name: 'Gaming Social',
-		date: getDateTime(2023, 11, 15, 18),
-		location: 'Ackerman Bruin Reception Room',
+		date: getDateTime(2023, 11, 19, 14),
+		location: 'Saxon Lounge',
 		imgFilePath: 'event/2023f-hackfam-banner.png',
 		detailLink: 'https://hoth.uclaacm.com/'
 	},


### PR DESCRIPTION
# Changes

Update gaming social time and place to Nov 19, 2 PM

## Type of change

Please delete options that are not relevant.

- [x] Content Update (non-breaking change which updates the content of the website)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Related Issues

Link the relevant issue here
