### PR TITLE
fix: Hovering images on Event page do not cause the card to pop #417

### DIFF
--- a/src/components/EventCard/EventCard.js
+++ b/src/components/EventCard/EventCard.js
@@ -129,6 +129,7 @@ function EventCard({
 					style={{
 						position: 'relative',
 						zIndex: 1,
+						pointerEvents: 'none',
 						borderRadius: theme.shape.borderRadius * 2
 					}} // iOS border radius
 				/>


### PR DESCRIPTION
# Changes

This PR fixes the issue of card not popping on mouse enter by changing the style property 'pointer-events' to none.

Fixes #417 

https://github.com/uclaacm/hack.uclaacm.com/assets/84477094/10ccd210-7424-46fa-a1f3-21c00d68bbf5


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Related Issues

GatsbyImage not recognised as child of it's parent onMouseEnter #30952
https://github.com/gatsbyjs/gatsby/issues/30952