### PR TITLE
Feat: Make the blog page into 2 columns of blog post cards #402

### DIFF
--- a/src/components/BlogPage/BlogListItem.js
+++ b/src/components/BlogPage/BlogListItem.js
@@ -12,6 +12,11 @@ const styles = theme => ({
 		borderRadius: '20px',
 		boxShadow: '0 1px 15px rgba(201, 96, 255, 0.2)'
 	},
+	button: {
+		display: 'flex',
+		height: '100%',
+		alignItems: 'flex-start'
+	},
 	content: {
 		margin: theme.spacing(2, 1)
 	},
@@ -36,7 +41,7 @@ function BlogListItem({
 }) {
 	return (
 		<Card className={classes.container} variant='outlined'>
-			<CardActionArea>
+			<CardActionArea className={classes.button}>
 				<LinkNoStyle to={url}>
 					<CardContent className={classes.content}>
 						<Typography variant="h4" component="h2" color="primary" className={classes.title}>

--- a/src/components/BlogPage/BlogPageList.js
+++ b/src/components/BlogPage/BlogPageList.js
@@ -7,7 +7,7 @@ import BlogListItem from './BlogListItem';
 
 function BlogPageList({ data }) {
 	const blogItem = data.allMarkdownRemark.nodes.map(blog =>
-		<Grid key={blog.id} card xs={12} md={6} item>
+		<Grid key={blog.id} card xs={12} md={6} item style={{ display: 'flex' }}>
 			<BlogListItem
 				title={blog.frontmatter.title}
 				subtitle={blog.frontmatter.subtitle}

--- a/src/components/BlogPage/BlogPageList.js
+++ b/src/components/BlogPage/BlogPageList.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { List, ListItem } from '@material-ui/core';
+import { Grid, List } from '@material-ui/core';
 
 import BlogListItem from './BlogListItem';
 
 function BlogPageList({ data }) {
 	const blogItem = data.allMarkdownRemark.nodes.map(blog =>
-		<ListItem key={blog.id} disableGutters>
+		<Grid key={blog.id} card xs={12} md={6} item>
 			<BlogListItem
 				title={blog.frontmatter.title}
 				subtitle={blog.frontmatter.subtitle}
@@ -17,10 +17,12 @@ function BlogPageList({ data }) {
 				timeToRead={blog.timeToRead}
 				url={blog.fields.slug}
 			/>
-		</ListItem>);
+		</Grid>);
 	return (
 		<List disablePadding >
-			{blogItem}
+			<Grid container justifyContent="space-between" alignItems="stretch" spacing={4}>
+				{blogItem}
+			</Grid>
 		</List>
 	);
 }


### PR DESCRIPTION
# Changes

Added #402 , Two columns for Blog Post Cards.

Used **Grid** container to wrap the **list of Blog Post Cards** & also wrapped each card with **Grid** to give responsive width.

Styled the Grid (wrapping each card ) for equal height &  CardActionArea for proper hover effect

Before Styling CardActionArea:

https://github.com/uclaacm/hack.uclaacm.com/assets/84477094/dbabfc21-ba84-4bcc-8f81-5c46af0da596

After 

https://github.com/uclaacm/hack.uclaacm.com/assets/84477094/53a8a20f-c1ed-410d-b045-001aee5c271c

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Related Issues