### PR TITLE
Fixed stackschool + hack cloud links

### DIFF
--- a/src/data/archive/spring2023/hackcloud.yml
+++ b/src/data/archive/spring2023/hackcloud.yml
@@ -1,6 +1,6 @@
 - name: HackCloud
   quarter: Spring 2023
-  mainLink: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud
+  mainLink: https://github.com/uclaacm/hack-curriculum/tree/main/archive/hackcloud
   tags: ['aws', 'cloud computing', 'machine learning', 's3', 'ec2']
   directors:
   - Andy Lewis
@@ -8,7 +8,7 @@
 
   workshops:
   - name: 'Session 1: Intro to Cloud'
-    repo: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud/Session%201_%20Intro%20to%20Cloud
+    repo: https://github.com/uclaacm/hack-curriculum/tree/main/archive/hackcloud/1-intro-to-cloud
     slides: https://docs.google.com/presentation/d/1a9q5RX-Zm4N7WlFx7Xn0TanjuDSlVu6gsEcvSaeoXdE/edit?usp=sharing
     youtube: https://youtu.be/A9TgYnsPwFs
     tags: ['cloud computing', 'aws', 's3']
@@ -17,7 +17,7 @@
     - Katelyn Yu
 
   - name: 'Session 2: VM Computing'
-    repo: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud/Session%202_%20VM%20Computing
+    repo: https://github.com/uclaacm/hack-curriculum/tree/main/archive/hackcloud/2-vm-computing
     slides: https://docs.google.com/presentation/d/1a04fSUrM0lNZvqn1KKDXmr3kwype8WE_KIRmebB54bs/edit?usp=sharing
     youtube: https://youtu.be/y8cXeQsLIf0
     tags: ['vm computing', 'aws', 'ec2']
@@ -26,7 +26,7 @@
     - Satyen Subramaniam
 
   - name: 'Session 3: Serverless Computing'
-    repo: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud/Session%203_%20Serverless%20Computing
+    repo: https://github.com/uclaacm/hack-curriculum/tree/main/archive/hackcloud/3-serverless-computing
     slides: https://docs.google.com/presentation/d/1Ks0vzlODk4IIa13j1mklLcv2dN6veaHb4swsVQ57zlQ/edit?usp=sharing
     youtube: https://youtu.be/_wzJBDLTmro
     tags: ['serverless computing', 'crud api']
@@ -35,7 +35,7 @@
     - Andy Lewis
   
   - name: 'Session 4: DevOps + Cloud'
-    repo: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud/Session%204_%20DevOps%20and%20Cloud
+    repo: https://github.com/uclaacm/hack-curriculum/tree/main/archive/hackcloud/4-devops-and-cloud
     slides: https://docs.google.com/presentation/d/1kzxU0wBjXY__MxoPIz92rYSou5qcdyTtQC6-lc1yRgU/edit?usp=sharing
     youtube: https://youtu.be/ZllqqDFdAoc
     tags: ['docker', 'elastic beanstalk', 'devops', 'aws']
@@ -44,7 +44,7 @@
     - Nathan Zhang
   
   - name: 'Session 5: Machine Learning'
-    repo: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud/Session%205_%20Machine%20Learning
+    repo: https://github.com/uclaacm/hack-curriculum/tree/main/archive/hackcloud/5-machine-learning
     slides: https://docs.google.com/presentation/d/1_G4iydzRv4GZYNY15agMmyg1VHfQp6wz4hbJKeobG4I/edit?usp=sharing
     youtube: https://youtu.be/jL2SbQxiFGM
     tags: ['machine learning', 'supervised learning', 'unsupervised learning', 'sagemaker', 'aws']
@@ -53,7 +53,7 @@
     - Andy Lewis
   
   - name: 'Session 6: Not Data Science. Minecraft'
-    repo: https://github.com/uclaacm/hack-curriculum/tree/main/HackCloud/Session%206_%20Data%20Science
+    repo: https://github.com/uclaacm/hack-curriculum/tree/main/archive/hackcloud/6-data-science
     slides: https://docs.google.com/presentation/d/1zu2H9r9IymC8v8msOat-LroUw3Pw0ztE8_Ln9WJS2to/edit?usp=sharing
     youtube: https://youtu.be/_hEhW9STFmw
     tags: ['minecraft', 'aws', 'ec2']

--- a/src/data/archive/winter2023/stackschool.yml
+++ b/src/data/archive/winter2023/stackschool.yml
@@ -1,6 +1,6 @@
 - name: StackSchool
   quarter: Winter 2023
-  mainLink: https://github.com/uclaacm/hack-curriculum/tree/main/stackschool
+  mainLink: https://github.com/uclaacm/hack-curriculum/tree/main/archive/stackschool
   tags: ["fullstack", "mern", "mongodb", "express", "reactjs", "nodejs"]
   directors:
     - James Wu
@@ -8,7 +8,7 @@
 
   workshops:
     - name: "Session 1: Intro to Fullstack"
-      repo: https://github.com/uclaacm/hack-curriculum/tree/main/stackschool/1-intro-to-full-stack
+      repo: https://github.com/uclaacm/hack-curriculum/tree/main/archive/stackschool/1-intro-to-full-stack
       slides: https://docs.google.com/presentation/d/1Zn3jyHO7QTVQJxeyUJMpiafJbD4l0vokdyLDU3cUIlA/edit?usp=sharing
       tags: ["fullstack"]
       presenters:
@@ -16,7 +16,7 @@
         - Nathan Zhang
 
     - name: "Session 2: Databases and Asynchronous Programming"
-      repo: https://github.com/uclaacm/hack-curriculum/tree/main/stackschool/2-databases
+      repo: https://github.com/uclaacm/hack-curriculum/tree/main/archive/stackschool/2-databases
       slides: https://docs.google.com/presentation/d/1EuZU5pkk456BShSwnUgeFDVkcUJEoUCYIzOFuUEalfY/edit?usp=sharing
       youtube: https://youtu.be/5_pIkemZDoY
       tags: ["database", "mongodb", "async"]
@@ -25,7 +25,7 @@
         - Nathan Zhang
 
     - name: "Session 3: Servers and Web APIs"
-      repo: https://github.com/uclaacm/hack-curriculum/tree/main/stackschool/3-servers
+      repo: https://github.com/uclaacm/hack-curriculum/tree/main/archive/stackschool/3-servers
       slides: https://docs.google.com/presentation/d/10hb3tY3MGbPm0vairW4fOs33INpPb92QIaHFhs0zens/edit?usp=sharing
       youtube: https://www.youtube.com/watch?v=0KXd9ySglwU
       tags: ["backend", "nodejs", "express", "api"]
@@ -34,7 +34,7 @@
         - Satyen Subramaniam
 
     - name: "Session 4: Backend Integration"
-      repo: https://github.com/uclaacm/hack-curriculum/tree/main/stackschool/4-backend-integration
+      repo: https://github.com/uclaacm/hack-curriculum/tree/main/archive/stackschool/4-backend-integration
       slides: https://docs.google.com/presentation/d/1xvO43pGWRmKAiEWyRYXkFRH64PogFmU8n-7F19RJ6k4/edit?usp=sharing
       youtube: https://youtu.be/q8LQ3VOG1ck
       tags: ["frontend", "reactjs", "axios"]
@@ -43,7 +43,7 @@
         - Andy Lewis
     
     - name: "Session 5: CSS and Components"
-      repo: https://github.com/uclaacm/hack-curriculum/tree/main/stackschool/demo
+      repo: https://github.com/uclaacm/hack-curriculum/tree/main/archive/stackschool/demo
       slides: https://docs.google.com/presentation/d/1kqYJRW55RHyq2PiczFE2O3rZjaoLgTdjh2O_M6kBNNk/edit?usp=sharing
       youtube: https://youtu.be/TtpFBrd_bLE
       tags: ["frontend", "reactjs", "css", "components", "props"]
@@ -52,7 +52,7 @@
         - Shiyu Ye
 
     - name: "Session 6: Navigation"
-      repo: https://github.com/uclaacm/hack-curriculum/tree/main/stackschool/demo
+      repo: https://github.com/uclaacm/hack-curriculum/tree/main/archive/stackschool/demo
       slides: https://docs.google.com/presentation/d/1YTAxVC3H4_aV6WU-nw129mKO-75RVDTSxMj0gXbrgok/edit?usp=sharing
       youtube: https://youtu.be/voSsAJELyu0
       tags: ["frontend", "reactjs", "navigation"]


### PR DESCRIPTION
# Changes

I moved some stuff around in the hack curriculum repo and broke some links in the process, fixed here

## Type of change

Please delete options that are not relevant.

- [ ] Content Update (non-breaking change which updates the content of the website)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

