### PR TITLE
Rolling back dependabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ developed by ACM Hack’s Dev Team.
 - Nathan Zhang [(@nathanzzhang)](https://github.com/nathanzzhang)
 - Lillian Gonick [(@lilliangonick)](https://github.com/lilliangonick)
 - Max Akira Lee [(@maxywaxyy)](https://github.com/maxywaxyy)
+- Aazel Tan [(@aazeltan)](https://github.com/aazeltan)
 - Jenna Wang [(@ariyin)](https://github.com/ariyin)
 - Jakob Reinwald [(@jakobreinwald)](https://github.com/jakobreinwald)
 


### PR DESCRIPTION
The primary purpose of this is to roll back the main branch to the most recent version of dependabot that did not fail checks.

Updated README to add Aazel as a small change to generate a difference to create a PR, as push to main is disabled 
(;u;)
(I just want to roll this back but have spent like 2 hours on it and im at the end of my rope this should be so simple man)