### PR TITLE
Tweak FAQ styling

### DIFF
--- a/src/components/Home/FAQSection.jsx
+++ b/src/components/Home/FAQSection.jsx
@@ -36,7 +36,7 @@ const faqs = [
 			<>
 				We keep a record of all our past workshops which can be found on our
 				Github or the ACM YouTube channel! We are also currently in the process
-				of reconstructing our archive page-- it&apos;s not accessible at the
+				of reconstructing our archive page—it&apos;s not accessible at the
 				moment, but check back in a week, and it should be up and running.
 				Pardon the dust!
 			</>

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -19,6 +19,8 @@
 	--lightPink: #ffdbf1;
 	--pink: #fb71c4;
 	--gray: #666;
+	--newGray: #5f5667;
+	--newLightGray: #9689a1;
 
 	--hackPrimary: #c960ff;
 	--hackSecondaryV1: #c137d8;
@@ -27,8 +29,6 @@
 	--hackAccent: #ff477e;
 	--hackAccentV2: #fb71c4;
 	--cardGradientEnd: #d681f8;
-	--summaryTextColor: #5f5667;
-	--metadataTextColor: #9689a1;
 
 	--rounded-none: 0;
 	--rounded-sm: 0.125rem;

--- a/src/styles/Blog.css
+++ b/src/styles/Blog.css
@@ -91,13 +91,13 @@
 .blog-summary {
 	font-family: 'Westwood Sans';
 	font-size: 1.5rem;
-	color: var(--summaryTextColor);
+	color: var(--newGray);
 	text-decoration: none;
 	margin: 0;
 }
 
 .blog-metadata {
-	color: var(--metadataTextColor);
+	color: var(--newLightGray);
 	display: flex;
 	gap: 1.5rem;
 	flex-wrap: wrap;

--- a/src/styles/FAQSection.css
+++ b/src/styles/FAQSection.css
@@ -1,82 +1,92 @@
+@import url('https://cdn.jsdelivr.net/gh/uclaacm/westwood_sans/font.css');
+
 .faq-section {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 3rem 0 2rem;
-    background-color: var(--bgPink);
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding: 3rem 0 2rem;
+	background-color: var(--bgPink);
 }
 
 .faq-section .szh-accordion {
-    width: 60%;
+	width: 60%;
 }
 
 .faq-header {
-    text-align: left;
-    width: 60%;
+	text-align: left;
+	width: 60%;
 }
 
 .item {
-    background-color: white;
-    border-radius: var(--rounded-2xl);
-    box-shadow: 0 0px 8px 10px rgba(251, 113, 196, 0.05);
-    margin-bottom: 1rem;
+	background-color: white;
+	border-radius: var(--rounded-2xl);
+	box-shadow: 0 0px 8px 10px rgba(251, 113, 196, 0.05);
+	margin-bottom: 1rem;
 }
 
 .itemBtn {
-    width: 100%;
-    font-weight: 600;
-    padding: 1rem;
-    font-size: 1.6rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border: none;
-    background-image: linear-gradient(to right, #FB71C4, #D681F8);
-    color: white;
-    cursor: pointer;
-    border-radius: var(--rounded-2xl);
-    transition: border-radius 0.25s;
+	width: 100%;
+	font-weight: 600;
+	padding: 1rem;
+	font-size: 1.6rem;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	border: none;
+	background-image: linear-gradient(to right, #FB71C4, #D681F8);
+	color: white;
+	cursor: pointer;
+	border-radius: var(--rounded-2xl);
+	transition: border-radius 0.25s;
 }
 
 .itemBtnExpanded {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+	border-bottom-left-radius: 0;
+	border-bottom-right-radius: 0;
 }
 
 .itemContent {
-    transition: height 0.25s cubic-bezier(0, 0, 0, 1);
+	transition: height 0.25s cubic-bezier(0, 0, 0, 1);
 }
 
 .itemPanel {
-    padding: 1rem 1.5rem;
-    background-color: #ffffff;
-    border-radius: var(--rounded-2xl);
-    color: var(--gray);
-    line-height: 1.6;
-    font-size: 1.2rem;
-    font-weight: 500;
+	padding: 1rem 1.5rem;
+	background-color: #ffffff;
+	border-radius: var(--rounded-2xl);
+	color: var(--newGray);
+	font-family: 'Westwood Sans', sans-serif;
+	line-height: 1.6;
+	font-size: 1.2rem;
+	font-weight: 500;
 }
 
 .itemPanel a {
-    color: var(--pink);
-    text-decoration: none;
+	font-family: 'Westwood Sans', sans-serif;
+	color: var(--pink);
+	text-decoration: none;
+}
+
+.itemPanel a:hover {
+	font-family: 'Westwood Sans', sans-serif;
+	color: var(--pink);
+	text-decoration: underline;
 }
 
 .chevron {
-    transition: transform 0.2s ease;
-    color: white;
+	transition: transform 0.2s ease;
+	color: white;
 }
 
 .itemBtnExpanded .chevron {
-    transform: rotate(180deg);
+	transform: rotate(180deg);
 }
 
 @media (max-width: 1400px) {
-    .faq-section .szh-accordion {
-        width: 90%;
-    }
-    .faq-header {
-        width: 90%;
-    }
+	.faq-section .szh-accordion {
+		width: 90%;
+	}
+	.faq-header {
+		width: 90%;
+	}
 }


### PR DESCRIPTION
# Changes
Added `Westwood Sans` to answer text of FAQs to adhere to new revamped design in Figma. Also refactored CSS variable for new body colors we're using in the revamp. Also changed 4-space indents to 2-tabs in `FAQSection.css`.

## Type of change
- [x] Content Update (non-breaking change which updates the content of the website)

# Related Issues
N/A